### PR TITLE
Fixes for 4.11

### DIFF
--- a/darling/down_interruptible.c
+++ b/darling/down_interruptible.c
@@ -1,5 +1,12 @@
 #include <linux/semaphore.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#else
 #include <linux/sched.h>
+#define __set_current_state(state_value)  \
+        __set_task_state(current, state_value)
+#endif
 
 // Copied from kernel/locking/semaphore.c because down_interruptible_timeout()
 // doesn't exist.
@@ -25,7 +32,7 @@ static inline int __down_common(struct semaphore *sem, long state,
                         goto interrupted;
                 if (unlikely(timeout <= 0))
                         goto timed_out;
-                __set_task_state(task, state);
+                __set_current_state(state);
                 raw_spin_unlock_irq(&sem->lock);
                 timeout = schedule_timeout(timeout);
                 raw_spin_lock_irq(&sem->lock);

--- a/darling/task_registry.c
+++ b/darling/task_registry.c
@@ -21,7 +21,13 @@
 #include "evprocfd.h"
 #include <linux/rbtree.h>
 #include <linux/slab.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#else
 #include <linux/sched.h>
+#endif
+#include <linux/completion.h>
 #include <linux/printk.h>
 #include <linux/rwlock.h>
 #include <linux/atomic.h>


### PR DESCRIPTION
set_task_state was removed (replaced by set_current_state)
some stuff was moved to sched/signal.h