### PR TITLE
Add KERNELVERSION so that dmks builds against the right kernel version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,11 @@ CFLAGS_device_server.o := $(miggen_cflags)
 CFLAGS_clock_reply_user.o := $(miggen_cflags)
 CFLAGS_notify_user.o := $(miggen_cflags)
 
+# KERNELVERSION is a dmks variable to specify the right version of the kernel.
+# If this is not done like this, then when updating your kernel, you will
+# build against the wrong kernel
+KERNELVERSION = $(shell uname -r)
+
 # If KERNELRELEASE is defined, we've been invoked from the
 # kernel build system and can use its language.
 ifneq ($(KERNELRELEASE),)
@@ -275,7 +280,7 @@ ifneq ($(KERNELRELEASE),)
 # Otherwise we were called directly from the command
 # line; invoke the kernel build system.
 else
-	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+	KERNELDIR ?= /lib/modules/$(KERNELVERSION)/build
 	PWD := $(shell pwd)
 default:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
@@ -283,7 +288,7 @@ default:
 endif
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C /lib/modules/$(KERNELVERSION)/build M=$(PWD) modules
 
 clean:
 	find . \( -name '*.o' -or -name '*.ko' \) -delete


### PR DESCRIPTION
Once this is merged in, I can file a PR for darling to use this

## Problem

### TL;DR

- When dkms called the lkm `Makefile` to build against a new kernel, lkm always builds against the current kernel, resulting in a bad .ko file. Fixing this is very tedious, basically uninstalling and reinstalling `darling-mach` or manually removing modules.

### Deatils

- The lkm `Makefile` uses `uname -r` to determine the kernel version. This will only ever tell you the currently running version of the kernel.
- When you update the kernel in debian and fedora based OSes, dkms will be called to build the kernel modules against the new kernel while running the old kernel. This way, when you reboot, everything is ready to go and everyone is happy.

## Solution

1. Tell DKMS to tell make the kernel version (Future PR using [this](https://github.com/andyneff/darling/tree/bda72f7d66c9d6a36933dbc4e63eeacfd99b116b))
2. Have the lkm Makefile accept being passed the kernel version (KERNELVERSION, this PR)