### PR TITLE
Fix build for Linux 4.20

### DIFF
--- a/darling/pthread_kill.c
+++ b/darling/pthread_kill.c
@@ -21,6 +21,7 @@
 #include <asm/siginfo.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+#include <linux/signal_types.h>
 #include <asm/siginfo.h>
 #include <linux/rcupdate.h>
 #include <linux/sched.h>
@@ -37,7 +38,11 @@ int pthread_kill_trap(task_t task,
 	struct pthread_kill_args args;
 	int ret;
 	pid_t tid;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
+	struct kernel_siginfo info;
+#else
 	struct siginfo info;
+#endif
 	struct task_struct *t;
 	thread_t thread;
 	

--- a/osfmk/duct/duct_machine_rtclock.c
+++ b/osfmk/duct/duct_machine_rtclock.c
@@ -75,7 +75,11 @@ void clock_get_system_nanotime (clock_sec_t * secs, clock_nsec_t * nanosecs)
 
         // ktime_t     kt      = ktime_get_boottime ();
         struct linux_timespec       ltimespec;        
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
+        ltimespec = ktime_to_timespec(ktime_get_boottime());
+#else
         get_monotonic_boottime (&ltimespec);
+#endif
 
         *secs       = (clock_sec_t) ltimespec.tv_sec;
         *nanosecs   = (clock_nsec_t) ltimespec.tv_nsec;
@@ -88,7 +92,11 @@ void clock_get_system_microtime (clock_sec_t * secs, clock_usec_t * microsecs)
         
         // ktime_t     kt      = ktime_get_boottime ();
         struct linux_timespec       ltimespec;        
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
+        ltimespec = ktime_to_timespec(ktime_get_boottime());
+#else
         get_monotonic_boottime (&ltimespec);
+#endif
 
         *secs       = (clock_sec_t) ltimespec.tv_sec;
         *microsecs  = (clock_nsec_t) ltimespec.tv_nsec / NSEC_PER_USEC;


### PR DESCRIPTION
Fixed following error while building on linux version 4.20.3
```
darling/src/lkm/osfmk/duct/duct_machine_rtclock.c:78:9: error: implicit declaration of function ‘get_monotonic_boottime’; did you mean ‘getboottime’? [-Werror=implicit-function-declaration]
         get_monotonic_boottime (&ltimespec);
         ^~~~~~~~~~~~~~~~~~~~~~
         getboottime
```
```
darling/src/lkm/darling/pthread_kill.c: In function ‘pthread_kill_trap’:
darling/src/lkm/darling/pthread_kill.c:65:17: error: passing argument 1 of ‘clear_siginfo’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   clear_siginfo(&info);
                 ^~~~~
In file included from ./include/linux/syscalls.h:76,
                 from darling/src/lkm/osfmk/duct/duct.h:73,
                 from darling/src/lkm/darling/pthread_kill.h:22,
                 from darling/src/lkm/darling/pthread_kill.c:20:
./include/linux/signal.h:20:52: note: expected ‘kernel_siginfo_t *’ {aka ‘struct kernel_siginfo *’} but argument is of type ‘struct siginfo *’
 static inline void clear_siginfo(kernel_siginfo_t *info)
                                  ~~~~~~~~~~~~~~~~~~^~~~
darling/src/lkm/darling/pthread_kill.c:74:33: error: passing argument 2 of ‘send_sig_info’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   ret = send_sig_info(args.sig, &info, t);
```