### PR TITLE
Fix kernel module build on Linux >=5.1

### DIFF
--- a/darling/binfmt.c
+++ b/darling/binfmt.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <linux/mm.h>
+#include <linux/mman.h>
 #include <linux/slab.h>
 #include <linux/fs.h>
 #include <linux/file.h>

--- a/darling/binfmt_loader.c
+++ b/darling/binfmt_loader.c
@@ -32,6 +32,7 @@
 #   define MACH_HEADER_STRUCT mach_header_64
 #   define SECTION_STRUCT section_64
 #	define MAP_EXTRA 0
+#	define MAP_PRIVATE 0
 #elif defined(GEN_32BIT)
 #   define FUNCTION_NAME load32
 #   define SEGMENT_STRUCT segment_command

--- a/darling/binfmt_loader.c
+++ b/darling/binfmt_loader.c
@@ -32,7 +32,6 @@
 #   define MACH_HEADER_STRUCT mach_header_64
 #   define SECTION_STRUCT section_64
 #	define MAP_EXTRA 0
-#	define MAP_PRIVATE 0
 #elif defined(GEN_32BIT)
 #   define FUNCTION_NAME load32
 #   define SEGMENT_STRUCT segment_command

--- a/darling/traps.c
+++ b/darling/traps.c
@@ -385,7 +385,7 @@ static void darling_ipc_inherit(task_t old_task, task_t new_task)
 
 // No vma from 4.11
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-static int mach_mmap_fault(struct vm_fault *vmf)
+static unsigned int mach_mmap_fault(struct vm_fault *vmf)
 #else
 static int mach_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #endif

--- a/darling/traps.c
+++ b/darling/traps.c
@@ -385,7 +385,7 @@ static void darling_ipc_inherit(task_t old_task, task_t new_task)
 
 // No vma from 4.11
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-static unsigned int mach_mmap_fault(struct vm_fault *vmf)
+static vm_fault_t mach_mmap_fault(struct vm_fault *vmf)
 #else
 static int mach_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #endif


### PR DESCRIPTION
I have zero knowledge about Linux kernel development, but I guess it works now on 5.1, since `darling shell` is able to load the module on my PC. I defined `MAP_PRIVATE`, as the compiler said it was never declared before, and I have no idea if it's how it should be declared.