### PR TITLE
Fix build for Linux kernels >= 5.1

### DIFF
--- a/darling/binfmt.c
+++ b/darling/binfmt.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <linux/mm.h>
+#include <linux/mman.h>
 #include <linux/slab.h>
 #include <linux/fs.h>
 #include <linux/file.h>

--- a/darling/traps.c
+++ b/darling/traps.c
@@ -384,7 +384,9 @@ static void darling_ipc_inherit(task_t old_task, task_t new_task)
 }
 
 // No vma from 4.11
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+static vm_fault_t mach_mmap_fault(struct vm_fault *vmf)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int mach_mmap_fault(struct vm_fault *vmf)
 #else
 static int mach_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)


### PR DESCRIPTION
This an extension of the PR @mrtino submitted #5 related to issue darlinghq/darling#516
This fixes build issues on Linux Kernel >= 5.1 and does not break builds on older kernel versions.

Tested on **5.1.5-arch1-2-ARCH** & **4.15.0-1039-aws**