### PR TITLE
Use designated initializers for clock_ops

### DIFF
--- a/osfmk/kern/clock_oldops.c
+++ b/osfmk/kern/clock_oldops.c
@@ -150,9 +150,10 @@ kern_return_t	rtclock_getattr(
 	mach_msg_type_number_t	*count);
 
 struct clock_ops sysclk_ops = {
-	rtclock_config,			rtclock_init,
-	rtclock_gettime,
-	rtclock_getattr,
+	.c_config  =	rtclock_config,
+	.c_init    =	rtclock_init,
+	.c_gettime =	rtclock_gettime,
+	.c_getattr =	rtclock_getattr
 };
 
 kern_return_t	calend_gettime(
@@ -164,9 +165,10 @@ kern_return_t	calend_getattr(
 	mach_msg_type_number_t	*count);
 
 struct clock_ops calend_ops = {
-	NULL, NULL,
-	calend_gettime,
-	calend_getattr,
+        .c_config  =    NULL,
+        .c_init    =    NULL,
+        .c_gettime =    calend_gettime,
+        .c_getattr =    calend_getattr
 };
 
 /*


### PR DESCRIPTION
Linux kernels have included some version of RANDSTRUCT for a while.
This GCC plugin needs to know where struct members are located in
order to shuffle them around in the same order for each instance of
the struct created.
This commit is applicable both to upstream and grsec-patched Linux.