### PR TITLE
Fixed kernel panic where executable load fails early.

### DIFF
--- a/darling/binfmt.c
+++ b/darling/binfmt.c
@@ -121,6 +121,9 @@ int macho_load(struct linux_binprm* bprm)
 	struct pt_regs* regs = current_pt_regs();
 	struct file* xnu_task;
 
+	// Zero this structure early
+	memset(&lr, 0, sizeof(lr));
+
 	// Do quick checks on the executable
 	err = test_load(bprm);
 	if (err)
@@ -145,7 +148,6 @@ int macho_load(struct linux_binprm* bprm)
 	if (err)
 		goto out;
 
-	memset(&lr, 0, sizeof(lr));
 	err = load(bprm, bprm->file, 0, &lr);
 
 	if (err)


### PR DESCRIPTION
The kernel will attempt to free an invalid pointer when given an executable file it doesn't expect.

Reproducable when attempting to execute an executable file with text in it. eg

> cat test.sh
echo foo

> chmod +x test.sh
> ./test.sh
