### PR TITLE
Work around renamed asm preprocessor macros on newer kernels

### DIFF
--- a/darling/continuation-asm.S
+++ b/darling/continuation-asm.S
@@ -1,5 +1,11 @@
 /* Copyright (C) 2018 Intel Corporation */
 #include <linux/linkage.h>
+#ifndef ENTRY
+#define ENTRY(name) SYM_FUNC_START(name)
+#endif
+#ifndef ENDPROC(name)
+#define ENDPROC(name) SYM_FUNC_END(name)
+#endif
 
 .text
 .align 8


### PR DESCRIPTION
Fixes https://github.com/darlinghq/darling/issues/691