### PR TITLE
More complete fixes to a kernel warning (darlinghq/darling#785)

### DIFF
--- a/bsd/kern/kern_event.c
+++ b/bsd/kern/kern_event.c
@@ -4987,13 +4987,13 @@ void
 knote_init(void)
 {
 	knote_zone = zinit(sizeof(struct knote), 8192*sizeof(struct knote),
-	                   8192, "knote zone");
+	                   8192, "knote_zone");
 
 	kqfile_zone = zinit(sizeof(struct kqfile), 8192*sizeof(struct kqfile),
-	                    8192, "kqueue file zone");
+	                    8192, "kqueue_file_zone");
 
 	kqworkq_zone = zinit(sizeof(struct kqworkq), 8192*sizeof(struct kqworkq),
-	                    8192, "kqueue workq zone");
+	                    8192, "kqueue_workq_zone");
 
 	/* allocate kq lock group attribute and group */
 	kq_lck_grp_attr = lck_grp_attr_alloc_init();

--- a/bsd/kern/sys_pipe.c
+++ b/bsd/kern/sys_pipe.c
@@ -278,7 +278,7 @@ pipeinit(void)
 	vm_size_t zone_size;
  
 	zone_size = 8192 * sizeof(struct pipe);
-        pipe_zone = zinit(sizeof(struct pipe), zone_size, 4096, "pipe zone");
+        pipe_zone = zinit(sizeof(struct pipe), zone_size, 4096, "pipe_zone");
 
 
 	/* allocate lock group attribute and group for pipe mutexes */
@@ -294,7 +294,7 @@ pipeinit(void)
 	zone_size = (PIPE_GARBAGE_QUEUE_LIMIT + 20) *
 	    sizeof(struct pipe_garbage);
         pipe_garbage_zone = (zone_t)zinit(sizeof(struct pipe_garbage),
-	    zone_size, 4096, "pipe garbage zone");
+	    zone_size, 4096, "pipe_garbage_zone");
 	pipe_garbage_lock = lck_mtx_alloc_init(pipe_mtx_grp, pipe_mtx_attr);
 	
 }

--- a/bsd/kern/sys_reason.c
+++ b/bsd/kern/sys_reason.c
@@ -73,7 +73,7 @@ os_reason_init()
 	 * Create OS reason zone.
 	 */
 	os_reason_zone = zinit(sizeof(struct os_reason), OS_REASON_MAX_COUNT * sizeof(struct os_reason),
-				OS_REASON_MAX_COUNT, "os reasons");
+				OS_REASON_MAX_COUNT, "os_reasons");
 	if (os_reason_zone == NULL) {
 		panic("failed to initialize os_reason_zone");
 	}

--- a/bsd/kern/ubc_subr.c
+++ b/bsd/kern/ubc_subr.c
@@ -706,7 +706,7 @@ ubc_init(void)
 
 	i = (vm_size_t) sizeof (struct ubc_info);
 
-	ubc_info_zone = zinit (i, 10000*i, 8192, "ubc_info zone");
+	ubc_info_zone = zinit (i, 10000*i, 8192, "ubc_info_zone");
 
 	zone_change(ubc_info_zone, Z_NOENCRYPT, TRUE);
 }

--- a/bsd/kern/uipc_socket.c
+++ b/bsd/kern/uipc_socket.c
@@ -432,7 +432,7 @@ socketinit(void)
 	    + get_inpcb_str_size() + 4 + get_tcp_str_size());
 
 	so_cache_zone = zinit(so_cache_zone_element_size,
-	    (120000 * so_cache_zone_element_size), 8192, "socache zone");
+	    (120000 * so_cache_zone_element_size), 8192, "socache_zone");
 	zone_change(so_cache_zone, Z_CALLERACCT, FALSE);
 	zone_change(so_cache_zone, Z_NOENCRYPT, TRUE);
 

--- a/bsd/netinet/tcp_subr.c
+++ b/bsd/netinet/tcp_subr.c
@@ -546,7 +546,7 @@ tcp_init(struct protosw *pp, struct domain *dp)
 
 	str_size = P2ROUNDUP(sizeof(struct sackhole), sizeof(u_int64_t));
 	sack_hole_zone = zinit(str_size, 120000*str_size, 8192,
-	    "sack_hole zone");
+	    "sack_hole_zone");
 	zone_change(sack_hole_zone, Z_CALLERACCT, FALSE);
 	zone_change(sack_hole_zone, Z_EXPAND, TRUE);
 

--- a/bsd/vfs/vfs_bio.c
+++ b/bsd/vfs/vfs_bio.c
@@ -2058,7 +2058,7 @@ bufzoneinit(void)
 					meta_zones[i].mz_name);
 		zone_change(meta_zones[i].mz_zone, Z_CALLERACCT, FALSE);
 	}
-	buf_hdr_zone = zinit(sizeof(struct buf), 32, PAGE_SIZE, "buf headers");
+	buf_hdr_zone = zinit(sizeof(struct buf), 32, PAGE_SIZE, "buf_headers");
 	zone_change(buf_hdr_zone, Z_CALLERACCT, FALSE);
 }
 

--- a/darling/psynch_support.c
+++ b/darling/psynch_support.c
@@ -4594,7 +4594,7 @@ ksyn_cvupdate_fixup(ksyn_wait_queue_t ckwq, uint32_t *updatep, ksyn_queue_t kfre
 void
 psynch_zoneinit(void)
 {
-        kwq_zone = (zone_t)zinit(sizeof(struct ksyn_wait_queue), 8192 * sizeof(struct ksyn_wait_queue), 4096, "ksyn_waitqueue zone");
-        kwe_zone = (zone_t)zinit(sizeof(struct ksyn_waitq_element), 8192 * sizeof(struct ksyn_waitq_element), 4096, "ksyn_waitq_element zone");
+        kwq_zone = (zone_t)zinit(sizeof(struct ksyn_wait_queue), 8192 * sizeof(struct ksyn_wait_queue), 4096, "ksyn_waitqueue_zone");
+        kwe_zone = (zone_t)zinit(sizeof(struct ksyn_waitq_element), 8192 * sizeof(struct ksyn_waitq_element), 4096, "ksyn_waitq_element_zone");
 }
 #endif

--- a/osfmk/duct/duct_kern_waitqueue.c
+++ b/osfmk/duct/duct_kern_waitqueue.c
@@ -128,7 +128,7 @@ void duct_waitq_bootstrap (void)
         zinit ( sizeof(struct waitq),
                 WAIT_QUEUE_MAX * sizeof(struct waitq),
                 sizeof(struct waitq ),
-                "wait queues" );
+                "wait_queues" );
 
         // WC zone_change(_waitq_zone, Z_NOENCRYPT, TRUE);
 
@@ -136,14 +136,14 @@ void duct_waitq_bootstrap (void)
         zinit ( sizeof(struct waitq_set),
                 WAIT_QUEUE_SET_MAX * sizeof(struct waitq_set),
                 sizeof(struct waitq_set),
-                "wait queue sets" );
+                "wait_queue_sets" );
         // WC zone_change(_waitq_set_zone, Z_NOENCRYPT, TRUE);
 
         _waitq_link_zone   =
         zinit ( sizeof(struct waitq_link),
                 WAIT_QUEUE_LINK_MAX * sizeof(struct waitq_link),
                 sizeof(struct waitq_link),
-                "wait queue links" );
+                "wait_queue_links" );
 
         // WC zone_change(_waitq_link_zone, Z_NOENCRYPT, TRUE);
 }

--- a/osfmk/duct/duct_vm_map.c
+++ b/osfmk/duct/duct_vm_map.c
@@ -64,7 +64,7 @@ void duct_vm_map_init (void)
 #if defined (__DARLING__)
 #else
     vm_size_t entry_zone_alloc_size;
-    const char *mez_name = "VM map entries";
+    const char *mez_name = "VM_map_entries";
 #endif
 
     vm_map_zone = zinit((vm_map_size_t) sizeof(struct _vm_map), 40*1024,
@@ -93,11 +93,11 @@ void duct_vm_map_init (void)
 //
 //     vm_map_entry_reserved_zone = zinit((vm_map_size_t) sizeof(struct vm_map_entry),
 //                    kentry_data_size * 64, kentry_data_size,
-//                    "Reserved VM map entries");
+//                    "Reserved_VM_map_entries");
 //     zone_change(vm_map_entry_reserved_zone, Z_NOENCRYPT, TRUE);
 //
 //     vm_map_copy_zone = zinit((vm_map_size_t) sizeof(struct vm_map_copy),
-//                  16*1024, PAGE_SIZE, "VM map copies");
+//                  16*1024, PAGE_SIZE, "VM_map_copies");
 //     zone_change(vm_map_copy_zone, Z_NOENCRYPT, TRUE);
 //
 //     /*

--- a/osfmk/i386/fpu.c
+++ b/osfmk/i386/fpu.c
@@ -361,7 +361,7 @@ fpu_module_init(void)
 	ifps_zone = zinit(fp_register_state_size,
 			  thread_max * fp_register_state_size,
 			  64 * fp_register_state_size,
-			  "x86 fpsave state");
+			  "x86_fpsave_state");
 
 	/* To maintain the required alignment, disable
 	 * zone debugging for this zone as that appends

--- a/osfmk/i386/pcb.c
+++ b/osfmk/i386/pcb.c
@@ -1673,12 +1673,12 @@ machine_thread_init(void)
 	iss_zone = zinit(sizeof(x86_saved_state_t),
 			thread_max * sizeof(x86_saved_state_t),
 			THREAD_CHUNK * sizeof(x86_saved_state_t),
-			"x86_64 saved state");
+			"x86_64_saved_state");
 
         ids_zone = zinit(sizeof(x86_debug_state64_t),
 			 thread_max * sizeof(x86_debug_state64_t),
 			 THREAD_CHUNK * sizeof(x86_debug_state64_t),
-			 "x86_64 debug state");
+			 "x86_64_debug_state");
 
 	fpu_module_init();
 }

--- a/osfmk/ipc/flipc.c
+++ b/osfmk/ipc/flipc.c
@@ -353,7 +353,7 @@ flipc_init(void)
     flipc_port_zone = zinit(sizeof(struct flipc_port),
                             (ipc_port_max>>4) * sizeof(struct flipc_port),
                             sizeof(struct flipc_port),
-                            "flipc ports");
+                            "flipc_ports");
 
     zone_change(flipc_port_zone, Z_CALLERACCT, FALSE);
     zone_change(flipc_port_zone, Z_NOENCRYPT, TRUE);

--- a/osfmk/ipc/ipc_importance.c
+++ b/osfmk/ipc/ipc_importance.c
@@ -3762,13 +3762,13 @@ ipc_importance_init(void)
 	ipc_importance_task_zone = zinit(sizeof(struct ipc_importance_task),
 					 ipc_importance_max * sizeof(struct ipc_importance_task),
 					 sizeof(struct ipc_importance_task),
-					 "ipc task importance");
+					 "ipc_task_importance");
 	zone_change(ipc_importance_task_zone, Z_NOENCRYPT, TRUE);
 
 	ipc_importance_inherit_zone = zinit(sizeof(struct ipc_importance_inherit),
 					    ipc_importance_max * sizeof(struct ipc_importance_inherit),
 					    sizeof(struct ipc_importance_inherit),
-					    "ipc importance inherit");
+					    "ipc_importance_inherit");
 	zone_change(ipc_importance_inherit_zone, Z_NOENCRYPT, TRUE);
 
 

--- a/osfmk/ipc/ipc_init.c
+++ b/osfmk/ipc/ipc_init.c
@@ -168,7 +168,7 @@ ipc_bootstrap(void)
 	ipc_space_zone = zinit(sizeof(struct ipc_space),
 			       ipc_space_max * sizeof(struct ipc_space),
 			       sizeof(struct ipc_space),
-			       "ipc spaces");
+			       "ipc_spaces");
 	zone_change(ipc_space_zone, Z_NOENCRYPT, TRUE);
 
 	/*
@@ -178,7 +178,7 @@ ipc_bootstrap(void)
 		zinit(sizeof(struct ipc_port),
 		      ipc_port_max * sizeof(struct ipc_port),
 		      sizeof(struct ipc_port),
-		      "ipc ports");
+		      "ipc_ports");
 	/* cant charge callers for port allocations (references passed) */
 	zone_change(ipc_object_zones[IOT_PORT], Z_CALLERACCT, FALSE);
 	zone_change(ipc_object_zones[IOT_PORT], Z_NOENCRYPT, TRUE);
@@ -187,7 +187,7 @@ ipc_bootstrap(void)
 		zinit(sizeof(struct ipc_pset),
 		      ipc_pset_max * sizeof(struct ipc_pset),
 		      sizeof(struct ipc_pset),
-		      "ipc port sets");
+		      "ipc_port_sets");
 	zone_change(ipc_object_zones[IOT_PORT_SET], Z_NOENCRYPT, TRUE);
 
 	/*
@@ -198,7 +198,7 @@ ipc_bootstrap(void)
 			      ipc_port_max * MACH_PORT_QLIMIT_DEFAULT *
 			      IKM_SAVED_KMSG_SIZE,
 			      IKM_SAVED_KMSG_SIZE,
-			      "ipc kmsgs");
+			      "ipc_kmsgs");
 	zone_change(ipc_kmsg_zone, Z_CALLERACCT, FALSE);
 
 	/* create special spaces */

--- a/osfmk/ipc/ipc_voucher.c
+++ b/osfmk/ipc/ipc_voucher.c
@@ -219,13 +219,13 @@ ipc_voucher_init(void)
 	ipc_voucher_zone = zinit(sizeof(struct ipc_voucher),
 				 ipc_voucher_max * sizeof(struct ipc_voucher),
 				 sizeof(struct ipc_voucher),
-				 "ipc vouchers");
+				 "ipc_vouchers");
 	zone_change(ipc_voucher_zone, Z_NOENCRYPT, TRUE);
 
 	ipc_voucher_attr_control_zone = zinit(sizeof(struct ipc_voucher_attr_control),
 				 attr_manager_max * sizeof(struct ipc_voucher_attr_control),
 				 sizeof(struct ipc_voucher_attr_control),
-				 "ipc voucher attr controls");
+				 "ipc_voucher_attr_controls");
 	zone_change(ipc_voucher_attr_control_zone, Z_NOENCRYPT, TRUE);
 
 	/* initialize voucher hash */

--- a/osfmk/kern/sched_multiq.c
+++ b/osfmk/kern/sched_multiq.c
@@ -350,7 +350,7 @@ sched_multiq_init(void)
 	                         sizeof(struct sched_group),
 	                         task_max * sizeof(struct sched_group),
 	                         PAGE_SIZE,
-	                         "sched groups");
+	                         "sched_groups");
 
 	zone_change(sched_group_zone, Z_NOENCRYPT, TRUE);
 	zone_change(sched_group_zone, Z_NOCALLOUT, TRUE);

--- a/osfmk/kern/thread.c
+++ b/osfmk/kern/thread.c
@@ -390,7 +390,7 @@ thread_init(void)
 		sizeof(struct thread_qos_override),
 		4 * thread_max * sizeof(struct thread_qos_override),
 		PAGE_SIZE,
-		"thread qos override");
+		"thread_qos_override");
 	zone_change(thread_qos_override_zone, Z_EXPAND, TRUE);
 	zone_change(thread_qos_override_zone, Z_COLLECT, TRUE);
 	zone_change(thread_qos_override_zone, Z_CALLERACCT, FALSE);

--- a/osfmk/kern/waitq.c
+++ b/osfmk/kern/waitq.c
@@ -1782,7 +1782,7 @@ void waitq_bootstrap(void)
 	waitq_set_zone = zinit(sizeof(struct waitq_set),
 			       WAITQ_SET_MAX * sizeof(struct waitq_set),
 			       sizeof(struct waitq_set),
-			       "waitq sets");
+			       "waitq_sets");
 	zone_change(waitq_set_zone, Z_NOENCRYPT, TRUE);
 
 	/* initialize the global waitq link table */

--- a/osfmk/vm/device_vm.c
+++ b/osfmk/vm/device_vm.c
@@ -126,7 +126,7 @@ device_pager_bootstrap(void)
 
 	size = (vm_size_t) sizeof(struct device_pager);
 	device_pager_zone = zinit(size, (vm_size_t) MAX_DNODE*size,
-				PAGE_SIZE, "device node pager structures");
+				PAGE_SIZE, "device_node_pager_structures");
 	zone_change(device_pager_zone, Z_CALLERACCT, FALSE);
 	return;
 }

--- a/osfmk/vm/vm_map.c
+++ b/osfmk/vm/vm_map.c
@@ -749,7 +749,7 @@ vm_map_init(
 	void)
 {
 	vm_size_t entry_zone_alloc_size;
-	const char *mez_name = "VM map entries";
+	const char *mez_name = "VM_map_entries";
 
 	vm_map_zone = zinit((vm_map_size_t) sizeof(struct _vm_map), 40*1024,
 			    PAGE_SIZE, "maps");
@@ -768,15 +768,15 @@ vm_map_init(
 
 	vm_map_entry_reserved_zone = zinit((vm_map_size_t) sizeof(struct vm_map_entry),
 				   kentry_data_size * 64, kentry_data_size,
-				   "Reserved VM map entries");
+				   "Reserved_VM_map_entries");
 	zone_change(vm_map_entry_reserved_zone, Z_NOENCRYPT, TRUE);
 
 	vm_map_copy_zone = zinit((vm_map_size_t) sizeof(struct vm_map_copy),
-				 16*1024, PAGE_SIZE, "VM map copies");
+				 16*1024, PAGE_SIZE, "VM_map_copies");
 	zone_change(vm_map_copy_zone, Z_NOENCRYPT, TRUE);
 
 	vm_map_holes_zone = zinit((vm_map_size_t) sizeof(struct vm_map_links),
-				 16*1024, PAGE_SIZE, "VM map holes");
+				 16*1024, PAGE_SIZE, "VM_map_holes");
 	zone_change(vm_map_holes_zone, Z_NOENCRYPT, TRUE);
 
 	/*

--- a/osfmk/vm/vm_object.c
+++ b/osfmk/vm/vm_object.c
@@ -598,7 +598,7 @@ vm_object_bootstrap(void)
 	vm_object_zone = zinit(vm_object_size,
 			       round_page(512*1024),
 			       round_page(12*1024),
-			       "vm objects");
+			       "vm_objects");
 	zone_change(vm_object_zone, Z_CALLERACCT, FALSE); /* don't charge caller */
 	zone_change(vm_object_zone, Z_NOENCRYPT, TRUE);
 
@@ -628,7 +628,7 @@ vm_object_bootstrap(void)
 			zinit((vm_size_t) sizeof (struct vm_object_hash_entry),
 			      round_page(512*1024),
 			      round_page(12*1024),
-			      "vm object hash entries");
+			      "vm_object_hash_entries");
 	zone_change(vm_object_hash_zone, Z_CALLERACCT, FALSE);
 	zone_change(vm_object_hash_zone, Z_NOENCRYPT, TRUE);
 

--- a/osfmk/vm/vm_resident.c
+++ b/osfmk/vm/vm_resident.c
@@ -1204,7 +1204,7 @@ vm_page_module_init(void)
 	vm_size_t	vm_page_with_ppnum_size;
 
 	vm_page_array_zone = zinit((vm_size_t) sizeof(struct vm_page),
-			     0, PAGE_SIZE, "vm pages array");
+			     0, PAGE_SIZE, "vm_pages_array");
 
 	zone_change(vm_page_array_zone, Z_CALLERACCT, FALSE);
 	zone_change(vm_page_array_zone, Z_EXPAND, FALSE);
@@ -1227,7 +1227,7 @@ vm_page_module_init(void)
 	vm_page_with_ppnum_size = (sizeof(struct vm_page_with_ppnum) + (VM_PACKED_POINTER_ALIGNMENT-1)) & ~(VM_PACKED_POINTER_ALIGNMENT - 1);
 
 	vm_page_zone = zinit(vm_page_with_ppnum_size,
-			     0, PAGE_SIZE, "vm pages");
+			     0, PAGE_SIZE, "vm_pages");
 
 	zone_change(vm_page_zone, Z_CALLERACCT, FALSE);
 	zone_change(vm_page_zone, Z_EXPAND, FALSE);

--- a/osfmk/x86_64/pmap.c
+++ b/osfmk/x86_64/pmap.c
@@ -785,7 +785,7 @@ pmap_init(void)
 	pmap_zone = zinit(s, 400*s, 4096, "pmap"); /* XXX */
         zone_change(pmap_zone, Z_NOENCRYPT, TRUE);
 
-	pmap_anchor_zone = zinit(PAGE_SIZE, task_max, PAGE_SIZE, "pagetable anchors");
+	pmap_anchor_zone = zinit(PAGE_SIZE, task_max, PAGE_SIZE, "pagetable_anchors");
 	zone_change(pmap_anchor_zone, Z_NOENCRYPT, TRUE);
 
 	/* The anchor is required to be page aligned. Zone debugging adds

--- a/security/mac_label.c
+++ b/security/mac_label.c
@@ -45,7 +45,7 @@ mac_labelzone_init(void)
 
 	zone_label = zinit(sizeof(struct label),
 	    8192 * sizeof(struct label),
-	    sizeof(struct label), "MAC Labels");
+	    sizeof(struct label), "MAC_Labels");
 	zone_change(zone_label, Z_EXPAND, TRUE);
 	zone_change(zone_label, Z_EXHAUST, FALSE);
 	zone_change(zone_label, Z_CALLERACCT, FALSE);


### PR DESCRIPTION
Fixes warnings of the form:

...
WARNING: CPU: 0 PID: 132182 at mm/slab_common.c:94 kmem_cache_create_usercopy+0x213/0x250
...

zinit()/duct_zinit() calls kmem_cache_create()/kmem_cache_create_usercopy() on Linux, which in
triggers the warning about name having spaces:

mm/slab_common.c:94 is:
    WARN_ON(strchr(name, ' ')); /* It confuses parsers */