### PR TITLE
pgprot argument to __vmalloc was removed in v5.8 kernels

### DIFF
--- a/osfmk/duct/duct_kern_kalloc.c
+++ b/osfmk/duct/duct_kern_kalloc.c
@@ -53,7 +53,11 @@ void * duct_kalloc (vm_size_t size)
 void * duct_kalloc_noblock (vm_size_t size)
 {
         // extern void *__vmalloc(unsigned long size, gfp_t gfp_mask, pgprot_t prot);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+        return __vmalloc (size, GFP_ATOMIC | __GFP_HIGHMEM);
+#else
         return __vmalloc (size, GFP_ATOMIC | __GFP_HIGHMEM, PAGE_KERNEL);
+#endif
 }
     
 extern void duct_kfree (void * data, vm_size_t size)


### PR DESCRIPTION
fixes https://github.com/darlinghq/darling/issues/860

Reference:

commit 88dca4ca5a93d2c09e5bbc6a62fbfc3af83c4fca
Author: Christoph Hellwig <hch@lst.de>
Date:   Mon Jun 1 21:51:40 2020 -0700

    mm: remove the pgprot argument to __vmalloc

    The pgprot argument to __vmalloc is always PAGE_KERNEL now, so remove it.