### PR TITLE
First (struct task_struct *tsk) argument to get_user_pages_remote was…

### DIFF
--- a/darling/binfmt.c
+++ b/darling/binfmt.c
@@ -582,7 +582,11 @@ struct page *macho_get_dump_page(unsigned long addr)
 	struct vm_area_struct *vma;
 	struct page *page;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	if (get_user_pages(1, FOLL_FORCE | FOLL_DUMP | FOLL_GET, &page, &vma) < 1)
+#else
 	if (get_user_pages(addr, 1, FOLL_FORCE | FOLL_DUMP | FOLL_GET, &page, &vma) < 1)
+#endif
 		return NULL;
 	flush_cache_page(vma, addr, page_to_pfn(page));
 	return page;

--- a/darling/binfmt.c
+++ b/darling/binfmt.c
@@ -582,11 +582,7 @@ struct page *macho_get_dump_page(unsigned long addr)
 	struct vm_area_struct *vma;
 	struct page *page;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
-	if (get_user_pages(1, FOLL_FORCE | FOLL_DUMP | FOLL_GET, &page, &vma) < 1)
-#else
 	if (get_user_pages(addr, 1, FOLL_FORCE | FOLL_DUMP | FOLL_GET, &page, &vma) < 1)
-#endif
 		return NULL;
 	flush_cache_page(vma, addr, page_to_pfn(page));
 	return page;

--- a/osfmk/duct/access_process_vm.h
+++ b/osfmk/duct/access_process_vm.h
@@ -23,7 +23,10 @@ static int __access_remote_vm_darling(struct task_struct *tsk, struct mm_struct 
                 void *maddr;
                 struct page *page = NULL;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+                ret = get_user_pages_remote(mm, addr, 1,
+                                gup_flags, &page, &vma, NULL);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
                 ret = get_user_pages_remote(tsk, mm, addr, 1,
                                 gup_flags, &page, &vma, NULL);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)

--- a/osfmk/duct/duct_vm_user.c
+++ b/osfmk/duct/duct_vm_user.c
@@ -528,7 +528,11 @@ mach_vm_remap(
 	struct page** pages = (struct page**) kmalloc(sizeof(struct page*) * nr_pages, GFP_KERNEL);
 	long got_pages;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	got_pages = get_user_pages_remote(src_map->linux_task->mm, page_start, nr_pages, gup_flags,
+#else
 	got_pages = get_user_pages_remote(NULL, src_map->linux_task->mm, page_start, nr_pages, gup_flags,
+#endif
 		pages, NULL, NULL);
 
 	if (got_pages == -LINUX_EFAULT)
@@ -537,7 +541,11 @@ mach_vm_remap(
 		gup_flags &= ~FOLL_WRITE;
 		map_prot &= ~PROT_WRITE;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+		got_pages = get_user_pages_remote(src_map->linux_task->mm, page_start, nr_pages, gup_flags,
+#else
 		got_pages = get_user_pages_remote(NULL, src_map->linux_task->mm, page_start, nr_pages, gup_flags,
+#endif
 			pages, NULL, NULL);
 	}
 


### PR DESCRIPTION
… removed in v5.9 kernels

fixes https://github.com/darlinghq/darling/issues/884

Reference:

commit 64019a2e467a288a16b65ab55ddcbf58c1b00187
Author: Peter Xu <peterx@redhat.com>
Date:   Tue Aug 11 18:39:01 2020 -0700

    mm/gup: remove task_struct pointer for all gup code

    After the cleanup of page fault accounting, gup does not need to pass
    task_struct around any more.  Remove that parameter in the whole gup
    stack.