### PR TITLE
Import necp_client_add_flow() from xnu-7195.50.7.100.1

### DIFF
--- a/bsd/net/necp.h
+++ b/bsd/net/necp.h
@@ -719,6 +719,7 @@ struct kev_necp_policies_changed_data {
 #define NECP_CLIENT_FLOW_FLAGS_USE_CLIENT_ID            0x02    // Register the client ID rather than the flow registration ID with network agents
 #define NECP_CLIENT_FLOW_FLAGS_BROWSE                      0x04    // Create request with a browse agent
 #define NECP_CLIENT_FLOW_FLAGS_RESOLVE                      0x08    // Create request with a resolution agent
+#define NECP_CLIENT_FLOW_FLAGS_OVERRIDE_ADDRESS                      0x10    // Flow has a different remote address than the parent flow
 
 struct necp_client_flow_stats {
 	u_int32_t stats_type; // NECP_CLIENT_STATISTICS_TYPE_*


### PR DESCRIPTION
[Foxlet](https://github.com/foxlet/minimal-amd-xnu) had identified the need for some applications to use `NECP_CLIENT_ACTION_ADD_FLOW` and implemented https://github.com/foxlet/minimal-amd-xnu/commit/9fd3812e827116979255b6914ddabefa40b9c66e for stability purposes, Apple finally released the source for the relevant logic in xnu-7195.50.7.100.1

`darling-newlkm` never implemented the stub but some applications still apparently need it so it's better to err on the side of caution and implement `necp_client_add_flow`.

### Disclaimer

I found this while working on a separate project and haven't tested it with `darling-newlkm`